### PR TITLE
Extend its functions

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -4,8 +4,8 @@
 #include <vector>
 using namespace std;
 
-#include "DataStream.h"
-#include "Serializable.h"
+#include "serialize\DataStream.h"
+#include "serialize\Serializable.h"
 using namespace yazi::serialize;
 
 
@@ -34,10 +34,13 @@ int main()
 
     DataStream ds;
     std::set<int, std::greater<int>> s {5, 100, 0, 40, 25};
-    ds << a << s;
-    ds.save("a.out");
+    ds << s;
+    
+    std::set<int, std::greater<int>> receive;
 
-    for (const auto& i : s) {
+    ds >> receive;
+
+    for (const auto& i : receive) {
         std::cout << i << " ";
     }
     

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -32,8 +33,13 @@ int main()
     A a("kitty", 18);
 
     DataStream ds;
-    ds << a;
+    std::set<int, std::greater<int>> s {5, 100, 0, 40, 25};
+    ds << a << s;
     ds.save("a.out");
 
+    for (const auto& i : s) {
+        std::cout << i << " ";
+    }
+    
     return 0;
 }

--- a/serialize/DataStream.h
+++ b/serialize/DataStream.h
@@ -141,17 +141,17 @@ public:
     DataStream & operator >> (string & value);
     DataStream & operator >> (Serializable & value);
 
-    template <typename T>
-    DataStream & operator >> (std::vector<T> & value);
+    template<typename T, typename Alloc = std::allocator<T>>
+    DataStream & operator >> (std::vector<T, Alloc> & value);
 
-    template <typename T>
-    DataStream & operator >> (std::list<T> & value);
+    template<typename T, typename Alloc = std::allocator<T>>
+    DataStream & operator >> (std::list<T, Alloc> & value);
 
-    template <typename K, typename V>
-    DataStream & operator >> (std::map<K, V> & value);
+    template<typename K, typename V, typename Compare = std::less<K>, typename Alloc = std::allocator<std::pair<const K, V>>>
+    DataStream & operator >> (std::map<K, V, Compare, Alloc> & value);
 
-    template <typename T>
-    DataStream & operator >> (std::set<T> & value);
+    template<typename K, typename Compare = std::less<K>, typename Alloc = std::allocator<K>>
+    DataStream & operator >> (std::set<K, Compare, Alloc> & value);
 
 private:
     void reserve(int len);
@@ -336,29 +336,29 @@ DataStream & DataStream::operator << (const std::set<K, Compare, Alloc> & value)
     return *this;
 }
 
-template <typename T>
-DataStream & DataStream::operator >> (std::vector<T> & value)
+template<typename T, typename Alloc>
+DataStream & DataStream::operator >> (std::vector<T, Alloc> & value)
 {
     read(value);
     return *this;
 }
 
-template <typename T>
-DataStream & DataStream::operator >> (std::list<T> & value)
+template<typename T, typename Alloc>
+DataStream & DataStream::operator >> (std::list<T, Alloc> & value)
 {
     read(value);
     return *this;
 }
 
-template <typename K, typename V>
-DataStream & DataStream::operator >> (std::map<K, V> & value)
+template<typename K, typename V, typename Compare, typename Alloc>
+DataStream & DataStream::operator >> (std::map<K, V, Compare, Alloc> & value)
 {
     read(value);
     return *this;
 }
 
-template <typename T>
-DataStream & DataStream::operator >> (std::set<T> & value)
+template<typename K, typename Compare, typename Alloc>
+DataStream & DataStream::operator >> (std::set<K, Compare, Alloc> & value)
 {
     read(value);
     return *this;


### PR DESCRIPTION
### 重写了序列化容器的接口：
使得**基于不同`Allocator`、`Compare Functor`的容器**也能完成序列化、反序列化的功能